### PR TITLE
fix: getexecutorname returning a version

### DIFF
--- a/StuLuau/Environment/UNC/Globals.cpp
+++ b/StuLuau/Environment/UNC/Globals.cpp
@@ -202,7 +202,7 @@ namespace RbxStu::StuLuau::Environment::UNC {
 
     int Globals::getexecutorname(lua_State *L) {
         lua_pushstring(L, "RbxStu");
-        return 2;
+        return 1;
     }
 
     int Globals::lz4compress(lua_State *L) {

--- a/StuLuau/Environment/UNC/Globals.cpp
+++ b/StuLuau/Environment/UNC/Globals.cpp
@@ -200,6 +200,11 @@ namespace RbxStu::StuLuau::Environment::UNC {
         return 2;
     }
 
+    int Globals::getexecutorname(lua_State *L) {
+        lua_pushstring(L, "RbxStu");
+        return 2;
+    }
+
     int Globals::lz4compress(lua_State *L) {
         const auto executionEngine =
                 Scheduling::TaskSchedulerOrchestrator::GetSingleton()->GetTaskScheduler()->GetExecutionEngine(L);
@@ -880,7 +885,7 @@ namespace RbxStu::StuLuau::Environment::UNC {
                 {"getreg", RbxStu::StuLuau::Environment::UNC::Globals::getreg},
 
                 {"identifyexecutor", RbxStu::StuLuau::Environment::UNC::Globals::identifyexecutor},
-                {"getexecutorname", RbxStu::StuLuau::Environment::UNC::Globals::identifyexecutor},
+                {"getexecutorname", RbxStu::StuLuau::Environment::UNC::Globals::getexecutorname},
 
                 {"lz4compress", RbxStu::StuLuau::Environment::UNC::Globals::lz4compress},
                 {"lz4decompress", RbxStu::StuLuau::Environment::UNC::Globals::lz4decompress},

--- a/StuLuau/Environment/UNC/Globals.hpp
+++ b/StuLuau/Environment/UNC/Globals.hpp
@@ -26,6 +26,8 @@ namespace RbxStu::StuLuau::Environment::UNC {
 
         static int identifyexecutor(lua_State *L);
 
+        static int getexecutorname(lua_State *L);
+
         static int lz4compress(lua_State *L);
 
         static int lz4decompress(lua_State *L);


### PR DESCRIPTION
- `getexecutorname` now only returns the executor's name like its supposed to